### PR TITLE
Add Workflows Linter to CI

### DIFF
--- a/.github/workflows/lint_workflows.yml
+++ b/.github/workflows/lint_workflows.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint_workflows:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint Workflows
+        uses: diamondlightsource/workflows@main

--- a/.workflows-lint.yaml
+++ b/.workflows-lint.yaml
@@ -1,0 +1,2 @@
+charts:
+  - helm-based-workflows

--- a/helm-based-workflows/templates/convert-to-dat.yaml
+++ b/helm-based-workflows/templates/convert-to-dat.yaml
@@ -8,7 +8,7 @@ metadata:
     workflows.argoproj.io/title: Convert .nxs to .dat
     workflows.argoproj.io/description: |
       Does what it says on the tin.
-    workflows.argoproj.io/repository: |
+    workflows.diamond.ac.uk/repository: |
       "https://github.com/DiamondLightSource/magnetic-materials-workflows"
     workflows.diamond.ac.uk/parameter-schema: |
       {{- .Files.Get "schemas/convert-to-dat_param.json" | nindent 6 }}
@@ -23,6 +23,11 @@ spec:
         configMapKeyRef:
           name: sessionspaces
           key: data_directory
+    - name: scan_numbers
+    - name: dat_file
+    - name: all_scans
+    - name: write_tiff
+    - name: overwrite
   volumes:
   - name: session
     hostPath:
@@ -36,16 +41,9 @@ spec:
       resources:
         requests:
           storage: 1Gi
-        storageClassName: netapp
+      storageClassName: netapp
   templates:
   - name: convert-to-dat
-    inputs:
-      parameters:
-      - name: scan_numbers
-      - name: dat_file
-      - name: all_scans
-      - name: write_tiff
-      - name: overwrite
     script:
       image: ghcr.io/diamondlightsource/magnetic-materials-workflows
       volumeMounts:
@@ -60,11 +58,11 @@ spec:
         # run notebook
         python -m papermill /tmp/notebook.ipynb /tmp/notebook.ipynb \
           -p datadir "{{`{{ workflow.parameters.visitdir }}`}}" \
-          -p scan_numbers_string "{{`{{ inputs.parameters.scan_numbers }}`}}" \
-          -p dat_file "{{`{{ inputs.parameters.dat_file }}`}}" \
-          -p all_scans "{{`{{ inputs.parameters.all_scans }}`}}" \
-          -p write_tiff "{{`{{ inputs.parameters.write_tiff }}`}}" \
-          -p overwrite "{{`{{ inputs.parameters.overwrite }}`}}"
+          -p scan_numbers_string "{{`{{ workflow.parameters.scan_numbers }}`}}" \
+          -p dat_file "{{`{{ workflow.parameters.dat_file }}`}}" \
+          -p all_scans "{{`{{ workflow.parameters.all_scans }}`}}" \
+          -p write_tiff "{{`{{ workflow.parameters.write_tiff }}`}}" \
+          -p overwrite "{{`{{ workflow.parameters.overwrite }}`}}"
         python -m nbconvert --to html --output notebook --output-dir /tmp /tmp/notebook.ipynb
     outputs:
       artifacts:

--- a/helm-based-workflows/templates/list-and-plot.yaml
+++ b/helm-based-workflows/templates/list-and-plot.yaml
@@ -23,6 +23,16 @@ spec:
         configMapKeyRef:
           name: sessionspaces
           key: data_directory
+    - name: scan_numbers
+    - name: all_scans
+    - name: print_start_time
+    - name: print_cmd
+    - name: print_temp
+    - name: print_energy
+    - name: print_sx
+    - name: print_sy
+    - name: print_sz
+    - name: other_vars
   volumes:
   - name: session
     hostPath:
@@ -36,21 +46,9 @@ spec:
       resources:
         requests:
           storage: 1Gi
-        storageClassName: netapp
+      storageClassName: netapp
   templates:
   - name: list-and-plot
-    inputs:
-      parameters:
-      - name: scan_numbers
-      - name: all_scans
-      - name: print_start_time
-      - name: print_cmd
-      - name: print_temp
-      - name: print_energy
-      - name: print_sx
-      - name: print_sy
-      - name: print_sz
-      - name: other_vars
     script:
       image: ghcr.io/diamondlightsource/magnetic-materials-workflows
       volumeMounts:
@@ -65,16 +63,16 @@ spec:
         # run notebook
         python -m papermill /tmp/notebook.ipynb /tmp/notebook.ipynb \
           -p datadir "{{`{{ workflow.parameters.visitdir }}`}}" \
-          -p scan_numbers_string "{{`{{ inputs.parameters.scan_numbers }}`}}" \
-          -p all_scans "{{`{{ inputs.parameters.all_scans }}`}}" \
-          -p print_start_time "{{`{{ inputs.parameters.print_start_time }}`}}" \
-          -p print_cmd "{{`{{ inputs.parameters.print_cmd }}`}}" \
-          -p print_temp "{{`{{ inputs.parameters.print_temp }}`}}" \
-          -p print_energy "{{`{{ inputs.parameters.print_energy}}`}}" \
-          -p print_sx "{{`{{ inputs.parameters.print_sx }}`}}" \
-          -p print_sy "{{`{{ inputs.parameters.print_sy }}`}}" \
-          -p print_sz "{{`{{ inputs.parameters.print_sz }}`}}" \
-          -p other_vars "{{`{{ inputs.parameters.other_vars }}`}}"
+          -p scan_numbers_string "{{`{{ workflow.parameters.scan_numbers }}`}}" \
+          -p all_scans "{{`{{ workflow.parameters.all_scans }}`}}" \
+          -p print_start_time "{{`{{ workflow.parameters.print_start_time }}`}}" \
+          -p print_cmd "{{`{{ workflow.parameters.print_cmd }}`}}" \
+          -p print_temp "{{`{{ workflow.parameters.print_temp }}`}}" \
+          -p print_energy "{{`{{ workflow.parameters.print_energy}}`}}" \
+          -p print_sx "{{`{{ workflow.parameters.print_sx }}`}}" \
+          -p print_sy "{{`{{ workflow.parameters.print_sy }}`}}" \
+          -p print_sz "{{`{{ workflow.parameters.print_sz }}`}}" \
+          -p other_vars "{{`{{ workflow.parameters.other_vars }}`}}"
         python -m nbconvert --to html --output notebook --output-dir /tmp /tmp/notebook.ipynb
     outputs:
       artifacts:

--- a/helm-based-workflows/templates/mmg-notebook.yaml
+++ b/helm-based-workflows/templates/mmg-notebook.yaml
@@ -4,6 +4,8 @@ metadata:
   name: mmg-test-notebook
   labels:
     workflows.diamond.ac.uk/science-group-magnetic-materials: "true"
+  annotations:
+    workflows.diamond.ac.uk/repository: "https://github.com/DiamondLightSource/magnetic-materials-workflows"
 spec:
   entrypoint: mmg-test-notebook
   arguments:

--- a/helm-based-workflows/templates/python_script.yaml
+++ b/helm-based-workflows/templates/python_script.yaml
@@ -4,6 +4,8 @@ metadata:
   name: mmg-test-python
   labels:
     workflows.diamond.ac.uk/science-group-magnetic-materials: "true"
+  annotations:
+    workflows.diamond.ac.uk/repository: "https://github.com/DiamondLightSource/magnetic-materials-workflows"
 spec:
   entrypoint: mmg-test-python
   arguments:


### PR DESCRIPTION
Enable linting of workflows in CI.

This helps to prevent broken ClusterWorkflowTemplates getting synced into the workflows system.